### PR TITLE
Remove JSDoc comments for generatePDFfromHTML function

### DIFF
--- a/utils/pdfGenerator.js
+++ b/utils/pdfGenerator.js
@@ -1,14 +1,5 @@
 const puppeteer = require('puppeteer');
 
-/**
- * Generates a PDF buffer from the provided HTML content using Puppeteer.
- *
- * @async
- * @function generatePDFfromHTML
- * @param {string} htmlContent - The HTML content to convert into a PDF. Must be a non-empty string.
- * @returns {Promise<Buffer>} A promise that resolves to a Buffer containing the generated PDF data.
- * @throws {Error} Throws an error if the HTML content is invalid, or if PDF generation fails.
- */
 async function generatePDFfromHTML(htmlContent) {
   if (!htmlContent || typeof htmlContent !== 'string' || htmlContent.trim() === '') {
     throw new Error('Invalid or empty HTML content provided to generatePDFfromHTML.');


### PR DESCRIPTION
Remove JSDoc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed the JSDoc comment block for the PDF generation function.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->